### PR TITLE
Add explicit resolver extensions to gatsby-node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -130,11 +130,11 @@ exports.sourceNodes = ({ actions }) => {
     type Frontmatter {
       title: String!
       author: String
-      date: Date!
+      date: Date! @dateformat
       path: String!
       tags: [String!]
       excerpt: String
-      coverImage: File
+      coverImage: File @fileByRelativePath
     }
   `
   createTypes(typeDefs)


### PR DESCRIPTION
Implied resolver extensions are deprecated in Gatsby v2 and will be removed in v3, causing deprecation warnings in the build output, and a GraphQL error when using gatsby-transformer-remark@>=2.6.10. This change fixes both problems.

Thanks to @fwojciec for the original PR: panr/gatsby-starter-hello-friend#10. See gatsbyjs/gatsby#17309 for more details. The new way this works is [documented on Gatsby's blog](https://www.gatsbyjs.org/blog/2019-05-17-improvements-to-schema-customization/#resolver-extensions
).